### PR TITLE
Uses core FieldType instead of custom type

### DIFF
--- a/x-pack/legacy/plugins/infra/public/graphql/types.ts
+++ b/x-pack/legacy/plugins/infra/public/graphql/types.ts
@@ -8,6 +8,8 @@
 // Types
 // ====================================================
 
+import { FieldType } from 'ui/index_patterns';
+
 export interface Query {
   /** Get an infrastructure data source by id.The resolution order for the source configuration attributes is as followswith the first defined value winning:1. The attributes of the saved object with the given 'id'.2. The attributes defined in the static Kibana configuration key'xpack.infra.sources.default'.3. The hard-coded default values.As a consequence, querying a source that doesn't exist doesn't error out,but returns the configured or hardcoded defaults. */
   source: InfraSource;
@@ -122,16 +124,8 @@ export interface InfraSourceStatus {
   indexFields: InfraIndexField[];
 }
 /** A descriptor of a field in an index */
-export interface InfraIndexField {
-  /** The name of the field */
-  name: string;
-  /** The type of the field's values as recognized by Kibana */
-  type: string;
-  /** Whether the field's values can be efficiently searched for */
-  searchable: boolean;
-  /** Whether the field's values can be aggregated */
-  aggregatable: boolean;
-}
+export interface InfraIndexField extends FieldType {}
+
 /** One metadata entry for a node. */
 export interface InfraNodeMetadata {
   id: string;

--- a/x-pack/legacy/plugins/infra/public/pages/infrastructure/snapshot/toolbar.tsx
+++ b/x-pack/legacy/plugins/infra/public/pages/infrastructure/snapshot/toolbar.tsx
@@ -106,7 +106,7 @@ export const SnapshotToolbar = injectI18n(({ intl }) => (
                     groupBy={groupBy}
                     nodeType={nodeType}
                     onChange={changeGroupBy}
-                    fields={derivedIndexPattern.fields as any}
+                    fields={derivedIndexPattern.fields}
                     onChangeCustomOptions={changeCustomOptions}
                     customOptions={customOptions}
                   />

--- a/x-pack/legacy/plugins/infra/server/graphql/types.ts
+++ b/x-pack/legacy/plugins/infra/server/graphql/types.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 import { InfraContext } from '../lib/infra_types';
 import { GraphQLResolveInfo } from 'graphql';
+import { FieldType } from 'ui/index_patterns';
 
 export type Resolver<Result, Parent = any, Context = any, Args = never> = (
   parent: Parent,
@@ -150,16 +151,8 @@ export interface InfraSourceStatus {
   indexFields: InfraIndexField[];
 }
 /** A descriptor of a field in an index */
-export interface InfraIndexField {
-  /** The name of the field */
-  name: string;
-  /** The type of the field's values as recognized by Kibana */
-  type: string;
-  /** Whether the field's values can be efficiently searched for */
-  searchable: boolean;
-  /** Whether the field's values can be aggregated */
-  aggregatable: boolean;
-}
+export interface InfraIndexField extends FieldType {}
+
 /** One metadata entry for a node. */
 export interface InfraNodeMetadata {
   id: string;


### PR DESCRIPTION
Updating the ts/indexPatterns PR to avoid `any` and have us use the correct type directly.