### PR TITLE
Add Discover request cancellation test

### DIFF
--- a/test/functional/apps/discover/group4/_request_cancellation.ts
+++ b/test/functional/apps/discover/group4/_request_cancellation.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import expect from '@kbn/expect';
+
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const retry = getService('retry');
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const filterBar = getService('filterBar');
+  const testSubjects = getService('testSubjects');
+  const PageObjects = getPageObjects(['common', 'discover', 'timePicker', 'header']);
+
+  describe('Discover request cancellation', () => {
+    before(async () => {
+      await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
+      await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
+    });
+
+    after(async () => {
+      await kibanaServer.importExport.unload('test/functional/fixtures/kbn_archiver/discover');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
+      await kibanaServer.savedObjects.cleanStandardList();
+      await PageObjects.timePicker.resetDefaultAbsoluteRangeViaUiSettings();
+    });
+
+    beforeEach(async () => {
+      await PageObjects.common.navigateToApp('discover');
+    });
+
+    it('should allow cancelling active requests', async () => {
+      await PageObjects.discover.selectIndexPattern('logstash-*');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      expect(await PageObjects.discover.hasNoResults()).to.be(false);
+      await testSubjects.existOrFail('querySubmitButton');
+      await testSubjects.missingOrFail('queryCancelButton');
+      await filterBar.addDslFilter(
+        JSON.stringify({
+          error_query: {
+            indices: [
+              {
+                error_type: 'none',
+                name: 'logstash-*',
+                stall_time_seconds: 30,
+              },
+            ],
+          },
+        }),
+        false
+      );
+      await retry.try(async () => {
+        await testSubjects.missingOrFail('querySubmitButton');
+        await testSubjects.existOrFail('queryCancelButton');
+      });
+      await testSubjects.click('queryCancelButton');
+      await retry.try(async () => {
+        expect(await PageObjects.discover.hasNoResults()).to.be(true);
+        await testSubjects.existOrFail('querySubmitButton');
+        await testSubjects.missingOrFail('queryCancelButton');
+      });
+      await filterBar.removeAllFilters();
+    });
+  });
+}

--- a/test/functional/apps/discover/group4/index.ts
+++ b/test/functional/apps/discover/group4/index.ts
@@ -34,5 +34,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./_hide_announcements'));
     loadTestFile(require.resolve('./_data_view_edit'));
     loadTestFile(require.resolve('./_field_list_new_fields'));
+    loadTestFile(require.resolve('./_request_cancellation'));
   });
 }

--- a/test/functional/services/filter_bar.ts
+++ b/test/functional/services/filter_bar.ts
@@ -321,7 +321,7 @@ export class FilterBarService extends FtrService {
     await this.addFilterAndSelectDataView(null, filter);
   }
 
-  public async addDslFilter(value: string) {
+  public async addDslFilter(value: string, waitUntilLoadingHasFinished = true) {
     await this.testSubjects.click('addFilter');
     await this.testSubjects.click('editQueryDSL');
     await this.monacoEditor.waitCodeEditorReady('addFilterPopover');
@@ -331,7 +331,9 @@ export class FilterBarService extends FtrService {
     await this.retry.try(async () => {
       await this.testSubjects.waitForDeleted('saveFilter');
     });
-    await this.header.waitUntilLoadingHasFinished();
+    if (waitUntilLoadingHasFinished) {
+      await this.header.waitUntilLoadingHasFinished();
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds a functional test to validate request cancellations in Discover.